### PR TITLE
feat: lowers read times, binds to 0.0.0.0, introduces support for non-blocking connection throttling

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -61,6 +61,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
 
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Test with Miri
+        run: cargo miri test
 
   clippy-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -61,18 +61,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
 
-  miri:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install Miri
-        run: |
-          rustup toolchain install nightly --component miri
-          rustup override set nightly
-          cargo miri setup
-      - name: Test with Miri
-        run: cargo miri test --lib
-
   clippy-check:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -71,7 +71,7 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        run: cargo miri test --lib
 
   clippy-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -62,7 +62,7 @@ jobs:
           files: ./coverage.xml
 
   miri:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3
       - name: Install Miri

--- a/src/server/common.rs
+++ b/src/server/common.rs
@@ -1,0 +1,1 @@
+//! Module providing common utilities for server abstractions.

--- a/src/server/impls/glommio/mod.rs
+++ b/src/server/impls/glommio/mod.rs
@@ -1,1 +1,4 @@
+//! Provides implementation of various server abstractions pertaining to the
+//! [`glommio`](https://docs.rs/glommio) runtime.
+
 pub mod hyper_compat;

--- a/src/server/impls/mod.rs
+++ b/src/server/impls/mod.rs
@@ -1,2 +1,4 @@
+//! Module providing implementations of various server abstractions.
+
 #[cfg(target_os = "linux")]
 pub mod glommio;

--- a/src/storage/commit_log/mod.rs
+++ b/src/storage/commit_log/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod test {
         Y: Deref<Target = [u8]>,
     {
         let count = futures_lite::stream::iter(expected_records)
-            .zip(indexed_read_stream(indexed_read, ..).await)
+            .zip(indexed_read_stream(indexed_read, ..))
             .map(|(y, record)| {
                 assert_eq!(y.deref(), record.value.deref());
                 Some(())

--- a/src/storage/commit_log/segmented_log/index.rs
+++ b/src/storage/commit_log/segmented_log/index.rs
@@ -420,7 +420,7 @@ pub(crate) mod test {
         Idx: ToPrimitive,
     {
         let count = futures_lite::stream::iter(index_records)
-            .zip(indexed_read_stream(index, ..).await)
+            .zip(indexed_read_stream(index, ..))
             .map(|(x, y)| {
                 assert_eq!(x, y);
                 Some(())

--- a/src/storage/common.rs
+++ b/src/storage/common.rs
@@ -1,22 +1,14 @@
 use super::AsyncIndexedRead;
 use futures_core::Stream;
-use num::CheckedSub;
+use num::{CheckedSub, Unsigned};
 use std::{cmp, ops::RangeBounds};
 
-/// Returns a stream of items spanning the given index bounds from the provided
-/// [`AsyncIndexedRead`] instance.
-pub fn indexed_read_stream<'a, R, RB>(
-    indexed_read: &'a R,
-    index_bounds: RB,
-) -> impl Stream<Item = R::Value> + 'a
+pub fn index_bounds_for_range<RB, Idx>(index_bounds: RB, lo_min: Idx, hi_max: Idx) -> (Idx, Idx)
 where
-    RB: RangeBounds<R::Idx>,
-    R: AsyncIndexedRead,
-    R::Value: 'a,
+    RB: RangeBounds<Idx>,
+    Idx: Unsigned + CheckedSub + Ord + Copy,
 {
-    let (lo_min, hi_max) = (indexed_read.lowest_index(), indexed_read.highest_index());
-
-    let one = <R::Idx as num::One>::one();
+    let one = <Idx as num::One>::one();
 
     let hi_max = hi_max - one;
 
@@ -33,6 +25,24 @@ where
     };
 
     let (lo, hi) = (cmp::max(lo, lo_min), cmp::min(hi, hi_max));
+
+    (lo, hi)
+}
+
+/// Returns a stream of items spanning the given index bounds from the provided
+/// [`AsyncIndexedRead`] instance.
+pub fn indexed_read_stream<'a, R, RB>(
+    indexed_read: &'a R,
+    index_bounds: RB,
+) -> impl Stream<Item = R::Value> + 'a
+where
+    RB: RangeBounds<R::Idx>,
+    R: AsyncIndexedRead,
+    R::Value: 'a,
+{
+    let (lo_min, hi_max) = (indexed_read.lowest_index(), indexed_read.highest_index());
+
+    let (lo, hi) = index_bounds_for_range(index_bounds, lo_min, hi_max);
 
     async_stream::stream! {
         for index in num::range_inclusive(lo, hi) {

--- a/src/storage/common.rs
+++ b/src/storage/common.rs
@@ -5,7 +5,7 @@ use std::{cmp, ops::RangeBounds};
 
 /// Returns a stream of items spanning the given index bounds from the provided
 /// [`AsyncIndexedRead`] instance.
-pub async fn indexed_read_stream<'a, R, RB>(
+pub fn indexed_read_stream<'a, R, RB>(
     indexed_read: &'a R,
     index_bounds: RB,
 ) -> impl Stream<Item = R::Value> + 'a


### PR DESCRIPTION
#### feat: lowers read times, binds to 0.0.0.0, introduces support for non-blocking connection throttling

- Uses binary search to find the segment containing the given record idx
- Provides API for external iteration using segment id (segment number) and record idx
- Provides an API for more efficient streaming by concatenating streams of all segments instead of looking up segments for every record index
- Provides entities for non-blocking connection throttling on conn limit semaphore
- Binds to 0.0.0.0:0 instead of a configured port to let the kernel allocate a free socket. This is necessary if launching an unknown number of server threads